### PR TITLE
Return None when str coercion fails or when empty

### DIFF
--- a/evaluation/calculate_score.py
+++ b/evaluation/calculate_score.py
@@ -32,8 +32,12 @@ def normalize_extracted_answer(extraction, choices, question_type, answer_type, 
         else:
             try:
                 extraction = str(extraction)
-            except:
-                extraction = ""
+            except Exception:
+                return None
+
+        # if the extraction is empty, return None
+        if not extraction:
+            return None
     
         # extract "A" from "(A) text"
         letter = re.findall(r'\(([a-zA-Z])\)', extraction)


### PR DESCRIPTION
- Returning None when extraction is empty prevents choosing one of the choices based on Levenshtein distance
- Also return None on str coercion failure since returning empty string would return None later anyways, and it also seems like an incorrect extraction fallback value

Fixes #19